### PR TITLE
Added Clipboard Conqueror

### DIFF
--- a/data/data.yaml
+++ b/data/data.yaml
@@ -95,6 +95,12 @@ extensions:
     link: "https://github.com/rjmacarthy/twinny"
     notes: "The most no-nonsense locally hosted AI code completion plugin for VS Code" 
 
+  - name: "Clipboard Conqueror"
+    editor: ["any"]
+    released: "2024-11-27"
+    link: "https://github.com/aseichter2007/ClipboardConqueror"
+    notes: "Copy-paste copilot integration alternative. No autocomplete. No integration. Manual context management made easy." 
+
 tools:
   - name: "gpt-engineer"
     stars: ">42k"


### PR DESCRIPTION
Added Clipboard Conqueror to "Extentions" so that people working in nonstandard editors have something to check out. It's not an extension though. It might belong all the way down in "Tools."